### PR TITLE
Add buyer profile API

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,3 @@
-from fastapi import APIRouter
-
 from app.api.routers.ai_config import router as ai_config_router
 from app.api.routers.conversation import router as conversation_router
 from app.api.routers.storefront import router as storefront_router
@@ -14,11 +12,18 @@ from app.api.v1.endpoints import (
 from app.api.v1.endpoints import storefront as storefront_content
 from app.api.v1.endpoints import storefront_catalog, websocket
 from app.api.v1.endpoints.behavior import router as behavior_router
+from app.api.v1.endpoints.buyer_profile import router as buyer_profile_router
 from app.api.v1.endpoints.complaint import router as complaint_router
 from app.api.v1.endpoints.content_moderation import router as content_moderation_router
-from app.api.v1.endpoints.domain_verification import router as domain_verification_router
+from app.api.v1.endpoints.domain_verification import (
+    router as domain_verification_router,
+)
+from app.api.v1.endpoints.notification_preferences import (
+    router as notification_preferences_router,
+)
 from app.api.v1.endpoints.violation import router as violation_router
 from app.api.v1.endpoints.whatsapp import router as whatsapp_router
+from fastapi import APIRouter
 
 api_router = APIRouter()
 
@@ -45,4 +50,12 @@ api_router.include_router(
     storefront_catalog.router, tags=["storefront-catalog"], prefix="/storefront-catalog"
 )
 api_router.include_router(whatsapp_router, tags=["whatsapp"], prefix="/whatsapp")
-api_router.include_router(domain_verification_router, tags=["domain-verification"], prefix="/domain")
+api_router.include_router(
+    domain_verification_router, tags=["domain-verification"], prefix="/domain"
+)
+api_router.include_router(
+    notification_preferences_router,
+    prefix="/notification-preferences",
+    tags=["notification-preferences"],
+)
+api_router.include_router(buyer_profile_router, prefix="/profile", tags=["profile"])

--- a/backend/app/api/v1/endpoints/buyer_profile.py
+++ b/backend/app/api/v1/endpoints/buyer_profile.py
@@ -1,0 +1,38 @@
+from app.api.deps import get_current_buyer, get_db
+from app.models.customer import Customer
+from app.schemas.customer import Customer as CustomerSchema
+from app.schemas.customer import CustomerUpdate
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter()
+
+
+@router.get("/", response_model=CustomerSchema)
+async def get_profile(
+    db: AsyncSession = Depends(get_db),
+    buyer=Depends(get_current_buyer),
+):
+    result = await db.execute(select(Customer).where(Customer.id == buyer.id))
+    customer = result.scalar_one_or_none()
+    if not customer:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    return customer
+
+
+@router.patch("/", response_model=CustomerSchema)
+async def update_profile(
+    profile_in: CustomerUpdate,
+    db: AsyncSession = Depends(get_db),
+    buyer=Depends(get_current_buyer),
+):
+    result = await db.execute(select(Customer).where(Customer.id == buyer.id))
+    customer = result.scalar_one_or_none()
+    if not customer:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    for field, value in profile_in.model_dump(exclude_unset=True).items():
+        setattr(customer, field, value)
+    await db.commit()
+    await db.refresh(customer)
+    return customer

--- a/backend/app/api/v1/endpoints/notification_preferences.py
+++ b/backend/app/api/v1/endpoints/notification_preferences.py
@@ -1,21 +1,31 @@
 import uuid
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.orm import Session
-from app.api.deps import get_db, get_current_buyer
-from app.models.notification_preferences import NotificationPreferences as NotificationPreferencesModel
-from app.schemas.notification_preferences import (
-    NotificationPreferencesBase, NotificationPreferencesUpdate, NotificationPreferencesResponse
+
+from app.api.deps import get_current_buyer, get_db
+from app.models.notification_preferences import (
+    NotificationPreferences as NotificationPreferencesModel,
 )
+from app.schemas.notification_preferences import (
+    NotificationPreferencesResponse,
+    NotificationPreferencesUpdate,
+)
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
 
 
 @router.get("/", response_model=NotificationPreferencesResponse)
-def get_my_notification_preferences(db: Session = Depends(get_db), buyer=Depends(get_current_buyer)):
-    prefs = db.query(NotificationPreferencesModel).filter(
-        NotificationPreferencesModel.customer_id == buyer.id,
-        NotificationPreferencesModel.tenant_id == buyer.tenant_id
-    ).first()
+async def get_my_notification_preferences(
+    db: AsyncSession = Depends(get_db), buyer=Depends(get_current_buyer)
+):
+    result = await db.execute(
+        select(NotificationPreferencesModel).where(
+            NotificationPreferencesModel.customer_id == buyer.id,
+            NotificationPreferencesModel.tenant_id == buyer.tenant_id,
+        )
+    )
+    prefs = result.scalar_one_or_none()
     if not prefs:
         # Create default preferences if not found
         prefs = NotificationPreferencesModel(
@@ -24,41 +34,47 @@ def get_my_notification_preferences(db: Session = Depends(get_db), buyer=Depends
             email_enabled=True,
             sms_enabled=False,
             whatsapp_enabled=False,
-            push_enabled=False
+            push_enabled=False,
         )
         db.add(prefs)
-        db.commit()
-        db.refresh(prefs)
+        await db.commit()
+        await db.refresh(prefs)
     return prefs
 
 
 @router.patch("/", response_model=NotificationPreferencesResponse)
-def update_my_notification_preferences(
+async def update_my_notification_preferences(
     prefs_in: NotificationPreferencesUpdate,
-    db: Session = Depends(get_db),
-    buyer=Depends(get_current_buyer)
+    db: AsyncSession = Depends(get_db),
+    buyer=Depends(get_current_buyer),
 ):
-    prefs = db.query(NotificationPreferencesModel).filter(
-        NotificationPreferencesModel.customer_id == buyer.id,
-        NotificationPreferencesModel.tenant_id == buyer.tenant_id
-    ).first()
+    result = await db.execute(
+        select(NotificationPreferencesModel).where(
+            NotificationPreferencesModel.customer_id == buyer.id,
+            NotificationPreferencesModel.tenant_id == buyer.tenant_id,
+        )
+    )
+    prefs = result.scalar_one_or_none()
     if not prefs:
         raise HTTPException(
-            status_code=404, detail="Notification preferences not found")
-    for field, value in prefs_in.dict(exclude_unset=True).items():
+            status_code=404, detail="Notification preferences not found"
+        )
+    for field, value in prefs_in.model_dump(exclude_unset=True).items():
         setattr(prefs, field, value)
-    db.commit()
-    db.refresh(prefs)
+    await db.commit()
+    await db.refresh(prefs)
     return prefs
 
 
 @router.delete("/{prefs_id}", status_code=204)
-def delete_notification_preferences(prefs_id: uuid.UUID, db: Session = Depends(get_db)):
-    prefs = db.query(NotificationPreferencesModel).filter(
-        NotificationPreferencesModel.id == prefs_id).first()
+async def delete_notification_preferences(
+    prefs_id: uuid.UUID, db: AsyncSession = Depends(get_db)
+):
+    prefs = await db.get(NotificationPreferencesModel, prefs_id)
     if not prefs:
         raise HTTPException(
-            status_code=404, detail="Notification preferences not found")
-    db.delete(prefs)
-    db.commit()
+            status_code=404, detail="Notification preferences not found"
+        )
+    await db.delete(prefs)
+    await db.commit()
     return None

--- a/backend/docs/api/buyer_profile.md
+++ b/backend/docs/api/buyer_profile.md
@@ -1,0 +1,19 @@
+# Buyer Profile API
+
+These endpoints allow a buyer to view and update their profile.
+
+## Get Profile
+
+```
+GET /api/v1/profile
+```
+
+Returns the currently authenticated buyer's profile. Responds with `404` if the account does not exist.
+
+## Update Profile
+
+```
+PATCH /api/v1/profile
+```
+
+Accepts partial fields from `CustomerUpdate` and returns the updated profile.

--- a/backend/tests/api/test_buyer_profile.py
+++ b/backend/tests/api/test_buyer_profile.py
@@ -1,0 +1,39 @@
+import uuid
+
+from app.models.customer import Customer
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from tests.fixtures.api import create_test_token
+
+
+def test_get_profile(client: TestClient, db_session: Session, test_tenant):
+    customer = Customer(id=uuid.uuid4(), name="Alice", email="alice@example.com")
+    db_session.add(customer)
+    db_session.commit()
+    db_session.refresh(customer)
+
+    token = create_test_token(subject=customer.id, tenant_id=test_tenant.id)
+    headers = {"Authorization": f"Bearer {token}", "X-Tenant-ID": str(test_tenant.id)}
+
+    resp = client.get("/api/v1/profile", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == str(customer.id)
+    assert data["name"] == "Alice"
+
+
+def test_update_profile(client: TestClient, db_session: Session, test_tenant):
+    customer = Customer(id=uuid.uuid4(), name="Alice", email="alice@example.com")
+    db_session.add(customer)
+    db_session.commit()
+    db_session.refresh(customer)
+
+    token = create_test_token(subject=customer.id, tenant_id=test_tenant.id)
+    headers = {"Authorization": f"Bearer {token}", "X-Tenant-ID": str(test_tenant.id)}
+
+    resp = client.patch("/api/v1/profile", json={"name": "Bob"}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Bob"
+    db_session.refresh(customer)
+    assert customer.name == "Bob"


### PR DESCRIPTION
## Summary
- add buyer_profile endpoints for reading/updating a customer
- switch notification preference endpoints to AsyncSession
- expose new routers from API router
- document buyer profile API
- test viewing and updating a profile

## Testing
- `mypy backend/app/api/v1/endpoints/buyer_profile.py backend/app/api/v1/endpoints/notification_preferences.py backend/app/api/v1/api.py backend/tests/api/test_buyer_profile.py`
- `pytest -q backend/tests/api/test_buyer_profile.py` *(fails: ModuleNotFoundError: No module named 'alembic.command')*

------
https://chatgpt.com/codex/tasks/task_e_685f8ea0a378832697e9c0bd2986efcf